### PR TITLE
github-actions-warnings-fixes

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
+        with:
+          # Avoid noisy cache-save races for the small binfmt image across concurrent runs.
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -69,7 +72,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
-          # build job already caches binfmt; saving again here races on the same GHA key
+          # Avoid noisy cache-save races for the small binfmt image across concurrent runs.
           cache-image: false
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Fixing the `Failed to save: Unable to reserve cache with key docker.io--tonistiigi--binfmt-latest-linux-x64, another job may be creating this cache.` warning in Github Actioncs