### PR TITLE
[Closed] Revert — dev setup workarounds not needed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Short caveats not obvious from file layout alone. See `docker/README.md`, `site/
 - Integrated dev mirrors production routing: run **`pnpm dev:lens`** and **`pnpm dev:site`**, open **`http://127.0.0.1:4321/`** (not Lens port alone for full-path testing).
 - Astro dev **proxies** `/lens*` and `/ingest` to Lens (`:3939`). Lens-only on `:3939` skips Astro quirks but is not the integrated path.
 - Lens requires **`STATIC_SERVER_PATH=lens`** in `lens/.env`.
-- For proxied dev, set **`TILE_SERVER_HOST=http://localhost:4321`** so tileserver-gl metadata URLs match the Astro origin. Direct Lens dev can use `http://localhost:3939`.
+- For proxied dev, set **`TILE_SERVER_HOST=http://127.0.0.1:4321`** so tileserver-gl metadata URLs match the Astro origin. Direct Lens dev can use `http://127.0.0.1:3939`. In development, tile URLs in TileJSON are rewritten to same-origin relative paths so `localhost` vs `[::1]` mismatches do not trigger CORS errors.
 - **`/lens` proxy works only in `astro dev`**, not `astro preview` or static `site/dist/`.
 
 ## Runtime config (secrets)

--- a/lens/README.md
+++ b/lens/README.md
@@ -24,7 +24,7 @@ Most of variables are set in the `.env` file. Typical content would be:
 MAPBOX_TOKEN=$YOUR_TOKEN
 RECREATE_DATABASE=
 STATIC_SERVER_PATH=
-TILE_SERVER_HOST=http://localhost:3939
+TILE_SERVER_HOST=http://127.0.0.1:3939
 TILE_SERVER_PATH=tiles
 AREA_SERVER_PATH=area
 TILES_PATH=../data/tiles

--- a/lens/src/server.mjs
+++ b/lens/src/server.mjs
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
 import { spawn } from 'child_process';
-import { createProxyMiddleware } from 'http-proxy-middleware';
+import { createProxyMiddleware, responseInterceptor } from 'http-proxy-middleware';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import dotenv from 'dotenv';
@@ -252,12 +252,53 @@ tileserver.on('close', (code) => {
 
 const tileServerPath = staticServerPath + tileSegment;
 const tileServerPathRewrite = '^/' + tileServerPath;
+const rewriteTileJsonToRelativePaths = process.env.NODE_ENV === 'development';
+
+function toSameOriginTileUrl(tileUrl) {
+    if (typeof tileUrl !== 'string' || tileUrl.startsWith('/')) {
+        return tileUrl;
+    }
+
+    const tileServerMount = '/' + tileServerPath;
+    if (tileServerUrl && tileUrl.startsWith(tileServerUrl)) {
+        return tileServerMount + tileUrl.slice(tileServerUrl.length);
+    }
+
+    try {
+        return decodeURIComponent(new URL(tileUrl).pathname);
+    } catch {
+        return tileUrl;
+    }
+}
 
 const tileserverProxy = createProxyMiddleware({
     target: 'http://localhost:8080',
     pathRewrite: {
         [tileServerPathRewrite]: ''
-    }
+    },
+    selfHandleResponse: rewriteTileJsonToRelativePaths,
+    onProxyRes: rewriteTileJsonToRelativePaths
+        ? responseInterceptor(async (responseBuffer, proxyRes, req, res) => {
+            const contentType = proxyRes.headers['content-type'] || '';
+            if (!contentType.includes('application/json') || !req.url?.endsWith('.json')) {
+                return responseBuffer;
+            }
+
+            try {
+                const payload = JSON.parse(responseBuffer.toString('utf8'));
+                if (Array.isArray(payload.tiles)) {
+                    payload.tiles = payload.tiles.map(toSameOriginTileUrl);
+                }
+
+                const body = JSON.stringify(payload);
+                res.setHeader('content-type', 'application/json; charset=utf-8');
+                res.setHeader('content-length', Buffer.byteLength(body));
+                return body;
+            } catch {
+                return responseBuffer;
+            }
+        })
+        : undefined,
 });
 
 app.use('/' + tileServerPath, limiter, tileserverProxy);

--- a/site/README.md
+++ b/site/README.md
@@ -17,7 +17,7 @@ pnpm dev:site   # terminal 2
 
 Open `http://127.0.0.1:4321/` and use **Explore the Map** — it should load Lens at `/lens/` via the Astro dev proxy.
 
-Set `TILE_SERVER_HOST=http://localhost:4321` in `lens/.env` so tile URLs work through the Astro proxy.
+Set `TILE_SERVER_HOST=http://127.0.0.1:4321` in `lens/.env` so tileserver-gl metadata URLs match the Astro origin. Avoid opening the site as `http://localhost:4321` or `http://[::1]:4321` unless those hostnames match `TILE_SERVER_HOST` exactly.
 
 Override the Lens upstream with `LENS_DEV_TARGET` if needed (default `http://127.0.0.1:3939`).
 

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prebuild": "mkdir -p public/vendor && cp node_modules/plotly.js-dist-min/plotly.min.js public/vendor/plotly.min.js",
     "predev": "pnpm run prebuild",
-    "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev",
+    "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev --host 127.0.0.1",
     "build": "ASTRO_TELEMETRY_DISABLED=1 astro build",
     "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview",
     "astro": "astro"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closing — not merging.

The original dev setup on `main` is correct. The tile/CORS issues seen in cloud-agent testing came from environment-specific behaviour (Astro binding to IPv6 `[::1]` in that VM, stub test data, and layered workarounds) rather than a bug in the repo.

No code changes required. Use integrated dev as documented: `pnpm dev:lens` + `pnpm dev:site`, open the site at the same hostname as `TILE_SERVER_HOST` in `lens/.env`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9a29136-27aa-458f-9aec-9d892fb27d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9a29136-27aa-458f-9aec-9d892fb27d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

