### PR TITLE
updated the metrics injest endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Short caveats not obvious from file layout alone. See `docker/README.md`, `site/
 ## Local dev
 
 - Integrated dev mirrors production routing: run **`pnpm dev:lens`** and **`pnpm dev:site`**, open **`http://127.0.0.1:4321/`** (not Lens port alone for full-path testing).
-- Astro dev **proxies** `/lens*` and `/ingest` to Lens (`:3939`). Lens-only on `:3939` skips Astro quirks but is not the integrated path.
+- Astro dev **proxies** `/lens*` and `/weef` to Lens (`:3939`). Lens-only on `:3939` skips Astro quirks but is not the integrated path.
 - Lens requires **`STATIC_SERVER_PATH=lens`** in `lens/.env`.
 - For proxied dev, set **`TILE_SERVER_HOST=http://localhost:4321`** so tileserver-gl metadata URLs match the Astro origin. Direct Lens dev can use `http://localhost:3939`.
 - **`/lens` proxy works only in `astro dev`**, not `astro preview` or static `site/dist/`.
@@ -25,7 +25,7 @@ Short caveats not obvious from file layout alone. See `docker/README.md`, `site/
 
 ## PostHog
 
-- Shared first-party ingest at **`/ingest`** (both site and Lens). Legacy **`/lens/ingest`** still proxied.
+- Shared first-party PostHog proxy at **`/weef`** (both site and Lens). Legacy **`/lens/weef`** still proxied.
 - Server-side events use `POSTHOG_API_KEY` in `lens/.env` / `docker/.env` (not the public key).
 
 ## Astro trailing-slash trap

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -15,8 +15,8 @@ POSTHOG_API_KEY=
 STATIC_SERVER_PATH=lens
 AREA_SERVER_PATH=area
 TILE_SERVER_PATH=tiles
-# Browser clients on / and /lens both send to /ingest (first-party proxy).
-POSTHOG_PROXY_PATH=ingest
+# Browser clients on / and /lens both send to /weef (first-party proxy).
+POSTHOG_PROXY_PATH=weef
 POSTHOG_HOST=https://eu.i.posthog.com
 
 # Public origin for tileserver-gl metadata URLs

--- a/docker/Caddyfile.wee-forest
+++ b/docker/Caddyfile.wee-forest
@@ -4,7 +4,7 @@
 # The single wee-forest-lens image serves:
 #   /        → Astro static site
 #   /lens*   → Lens app (map, tiles, area API)
-#   /ingest* → PostHog first-party proxy (shared by site and Lens)
+#   /weef* → PostHog first-party proxy (shared by site and Lens)
 #
 # Reload after edits:
 #   docker exec -w /etc/caddy caddy caddy reload

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@ Production runs as a **single Docker image** (`wee-forest-lens`) that serves:
 
 - `/` — Astro static site (`site/dist`)
 - `/lens*` — Lens map app, tile proxy, area API
-- `/ingest*` — PostHog first-party proxy (shared by site and Lens)
+- `/weef*` — PostHog first-party proxy (shared by site and Lens)
 
 Caddy terminates TLS and reverse-proxies all traffic to the app container.
 

--- a/lens/README.md
+++ b/lens/README.md
@@ -37,7 +37,7 @@ AREA_PORT=3939
 POSTHOG_API_KEY=
 POSTHOG_PUBLIC_API_KEY=
 POSTHOG_HOST=https://eu.i.posthog.com
-POSTHOG_PROXY_PATH=ingest
+POSTHOG_PROXY_PATH=weef
 ```
 
 With this setup, your tiles and area files are expected to be in the `../data` folder relative to the lens folder. Fields left empty are left so on purpose.
@@ -111,7 +111,7 @@ Barring the registry workflow, you can also archive the image and transfer it to
 
 ### Analytics
 
-Plausible has been removed. Browser analytics on both the landing page and Lens use `posthog-js` through a shared first-party `/ingest` path (configurable via `POSTHOG_PROXY_PATH`), which forwards to `POSTHOG_HOST` server-side. The legacy `/lens/ingest` path is still proxied for compatibility. The server also uses `posthog-node` to capture backend events such as area calculations.
+Plausible has been removed. Browser analytics on both the landing page and Lens use `posthog-js` through a shared first-party `/weef` path (configurable via `POSTHOG_PROXY_PATH`), which forwards to `POSTHOG_HOST` server-side. The legacy `/lens/weef` path is still proxied for compatibility. The server also uses `posthog-node` to capture backend events such as area calculations.
 
 ## Contributing
 

--- a/lens/src/client-config.ts
+++ b/lens/src/client-config.ts
@@ -19,6 +19,6 @@ export function getRuntimeConfig(): WeeForestRuntimeConfig {
 }
 
 export function getPostHogApiHost(config = getRuntimeConfig()): string {
-    const ingestPath = config.posthogProxyPath ?? 'ingest';
+    const ingestPath = config.posthogProxyPath ?? 'weef';
     return `${window.location.origin}/${ingestPath}`;
 }

--- a/lens/src/runtime-config.mjs
+++ b/lens/src/runtime-config.mjs
@@ -19,7 +19,7 @@ export function buildRuntimeConfigScript(env = process.env) {
         staticServerPath,
         areaServerPath: servicePath(staticServerPath, areaSegment),
         tileServerPath: servicePath(staticServerPath, tileSegment),
-        posthogProxyPath: env.POSTHOG_PROXY_PATH || 'ingest',
+        posthogProxyPath: env.POSTHOG_PROXY_PATH || 'weef',
     };
 
     return `window.__WEEFOREST_RUNTIME__=${JSON.stringify(config)};`;

--- a/lens/src/server.mjs
+++ b/lens/src/server.mjs
@@ -125,7 +125,7 @@ const staticServerSegment = normalizeSegment(process.env.STATIC_SERVER_PATH);
 const staticServerPath = staticServerSegment ? `${staticServerSegment}/` : '';
 const areaSegment = normalizeSegment(process.env.AREA_SERVER_PATH) || 'area';
 const tileSegment = normalizeSegment(process.env.TILE_SERVER_PATH) || 'tiles';
-const postHogIngestPath = normalizeSegment(process.env.POSTHOG_PROXY_PATH) || 'ingest';
+const postHogIngestPath = normalizeSegment(process.env.POSTHOG_PROXY_PATH) || 'weef';
 const postHogTarget = process.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
 
 function createPostHogProxy(mountPath) {

--- a/site/.env.example
+++ b/site/.env.example
@@ -1,6 +1,6 @@
 # Optional for local Astro dev only.
 # By default, astro dev loads PostHog/Mapbox values from lens/.env via /runtime-config.js.
 # Copy to site/.env only if you want to override the public API key without editing lens/.env.
-# Ingest goes through /ingest (proxied to Lens in dev, Express in production).
+# PostHog browser traffic goes through /weef (proxied to Lens in dev, Express in production).
 
 PUBLIC_POSTHOG_PUBLIC_API_KEY=

--- a/site/README.md
+++ b/site/README.md
@@ -21,7 +21,7 @@ Set `TILE_SERVER_HOST=http://localhost:4321` in `lens/.env` so tile URLs work th
 
 Override the Lens upstream with `LENS_DEV_TARGET` if needed (default `http://127.0.0.1:3939`).
 
-PostHog and Mapbox tokens for local dev are read from `lens/.env` via `/runtime-config.js` (served by Astro dev for `/` and proxied to Lens for `/lens/`). Analytics events from both the landing page and Lens go through `/ingest`, proxied to Lens in dev. A separate `site/.env` is optional — see `site/.env.example`.
+PostHog and Mapbox tokens for local dev are read from `lens/.env` via `/runtime-config.js` (served by Astro dev for `/` and proxied to Lens for `/lens/`). Analytics events from both the landing page and Lens go through `/weef`, proxied to Lens in dev. A separate `site/.env` is optional — see `site/.env.example`.
 
 Note: the `/lens` proxy applies to `astro dev` only, not `astro preview` or the static `dist/` build. Lens area API calls use a trailing slash (`/lens/area/calculate_areas/`) so Astro's `trailingSlash: 'always'` dev server forwards them to Lens instead of returning a 404.
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -30,6 +30,7 @@ loadEnvFile(path.join(repoRoot, '../lens/.env'));
 loadEnvFile(path.join(repoRoot, '.env'));
 
 const lensDevTarget = process.env.LENS_DEV_TARGET ?? 'http://127.0.0.1:3939';
+const posthogProxyPath = process.env.POSTHOG_PROXY_PATH || 'weef';
 
 function runtimeConfigPlugin() {
   return {
@@ -51,8 +52,8 @@ export default defineConfig({
     plugins: [tailwindcss(), runtimeConfigPlugin()],
     server: {
       proxy: {
-        // Mirror production: shared PostHog ingest + Lens app routes.
-        '/ingest': {
+        // Mirror production: shared PostHog proxy + Lens app routes.
+        [`/${posthogProxyPath}`]: {
           target: lensDevTarget,
           changeOrigin: true,
         },

--- a/site/src/components/PostHog.astro
+++ b/site/src/components/PostHog.astro
@@ -52,7 +52,7 @@ const devToken = import.meta.env.PUBLIC_POSTHOG_PUBLIC_API_KEY;
     const token = cfg.posthogPublicApiKey || devToken;
     if (!token) return;
 
-    const ingestPath = cfg.posthogProxyPath || 'ingest';
+    const ingestPath = cfg.posthogProxyPath || 'weef';
     posthog.init(token, {
       api_host: `${window.location.origin}/${ingestPath}`,
       ui_host: 'https://eu.posthog.com',


### PR DESCRIPTION
## Summary

Renames the first-party PostHog proxy path from `/ingest` to `/weef` (short for wee-forest) so browser analytics is less likely to be blocked by filter lists that target common ingest URLs.

The path remains configurable via `POSTHOG_PROXY_PATH`; this PR updates the default when that env var is unset. Astro dev proxy now reads the same env var so local integrated dev matches production.

## Test plan

- [ ] Set `POSTHOG_PROXY_PATH=weef` in `lens/.env` (or remove it to use the new default)
- [ ] Run `pnpm dev:lens` + `pnpm dev:site`, open `http://127.0.0.1:4321/`
- [ ] Confirm PostHog network requests go to `/weef/...`, not `/ingest/...`
- [ ] Repeat on `/lens/` and check `/lens/weef/...` still works when `STATIC_SERVER_PATH=lens`
- [ ] Update production `docker/.env` if it still sets `POSTHOG_PROXY_PATH=ingest`, then redeploy