### PR TITLE
Feat/nev 64 65 66 hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,13 @@ Short caveats not obvious from file layout alone. See `docker/README.md`, `site/
 - Express serves Lens at `/lens` (no `express.static` directory redirect) and 301s `/lens/` → `/lens`.
 - Lens `index.html` must use **root-absolute** asset URLs (`/lens/dist/...`, `/lens/runtime-config.js`). Relative `./dist/...` resolves to `/dist/...` when the page URL has no trailing slash.
 
+## Lens client state
+
+- **Zustand** holds Lens domain state (mode, dataset, years, view, features).
+- **React Context** only injects the store instance so tests/harness can mount an isolated store — not a second state tree.
+- **Local `useState`** for ephemeral UI (map bounds, swipe position) that must not live in the store or URL.
+- Multi-field object picks from the store should use Zustand `useShallow`. Do not split into slices for this app size.
+
 ## Production
 
 - **Single image** `wee-forest-lens`: Express serves Astro `site/dist` at `/` and Lens at `/lens*`. Caddy reverse-proxies everything to `:3939`.

--- a/lens/src/components/lens-app.tsx
+++ b/lens/src/components/lens-app.tsx
@@ -1,22 +1,26 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import type { WeeForestRuntimeConfig } from '@/client-config';
 import { BaseMapType, MapModeTypes } from '@/models/lens-config';
 import { isComparisonMode } from '@/models/lens-store';
-import { serializeLensUrl } from '@/models/lens-url';
 import { BaseMapSelector, DatasetSelector, ModeSelector } from '@/components/lens-controls';
 import { LensLegend, type MapBounds } from '@/components/lens-legend';
 import { LensMap } from '@/components/lens-map';
 import { useLensStore } from '@/components/lens-store-context';
+import { useLensUrlSync } from '@/hooks/use-lens-url-sync';
 
 type LensAppProps = {
     runtimeConfig: WeeForestRuntimeConfig;
 };
 
 export function LensApp({ runtimeConfig }: LensAppProps) {
-    const modeId = useLensStore((state) => state.modeId);
-    const datasetYear = useLensStore((state) => state.datasetYear);
-    const compareDatasetYear = useLensStore((state) => state.compareDatasetYear);
-    const basemapId = useLensStore((state) => state.basemapId);
+    const { modeId, datasetYear, compareDatasetYear, basemapId } = useLensStore(useShallow((state) => ({
+        modeId: state.modeId,
+        datasetYear: state.datasetYear,
+        compareDatasetYear: state.compareDatasetYear,
+        basemapId: state.basemapId,
+    })));
+    // Ephemeral map UI — not Lens domain state and not URL-persisted.
     const [primaryBounds, setPrimaryBounds] = useState<MapBounds>();
     const [comparisonBounds, setComparisonBounds] = useState<MapBounds>();
     const [swipePosition, setSwipePosition] = useState(50);
@@ -92,54 +96,4 @@ export function LensApp({ runtimeConfig }: LensAppProps) {
             ) : null}
         </>
     );
-}
-
-function useLensUrlSync() {
-    const modeId = useLensStore((state) => state.modeId);
-    const datasetId = useLensStore((state) => state.datasetId);
-    const datasetDataTypeId = useLensStore((state) => state.datasetDataTypeId);
-    const basemapId = useLensStore((state) => state.basemapId);
-    const datasetYear = useLensStore((state) => state.datasetYear);
-    const compareDatasetYear = useLensStore((state) => state.compareDatasetYear);
-    const viewState = useLensStore((state) => state.viewState);
-
-    useEffect(() => {
-        const timeout = window.setTimeout(() => {
-            const { query, url } = serializeLensUrl(new URL(window.location.href), {
-                coordinates: {
-                    lat: viewState.latitude,
-                    lng: viewState.longitude,
-                    zoom: viewState.zoom,
-                    pitch: viewState.pitch,
-                },
-                modeId,
-                datasetId,
-                datasetDataTypeId,
-                basemapId,
-                datasetYear,
-                compareDatasetYear,
-            });
-
-            try {
-                window.history.replaceState(null, '', query);
-            } catch (error) {
-                console.error('Failed to update the URL:', error);
-            }
-
-            const shareInput = document.getElementById('share-url');
-            if (shareInput instanceof HTMLInputElement) {
-                shareInput.value = url.toString();
-            }
-        }, 250);
-
-        return () => window.clearTimeout(timeout);
-    }, [
-        basemapId,
-        compareDatasetYear,
-        datasetDataTypeId,
-        datasetId,
-        datasetYear,
-        modeId,
-        viewState,
-    ]);
 }

--- a/lens/src/components/lens-controls.tsx
+++ b/lens/src/components/lens-controls.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { DatasetConfigs } from '@/models/dataset';
 import { BaseMaps, MapModes, MapModeTypes } from '@/models/lens-config';
 import { getDataset, isComparisonMode } from '@/models/lens-store';
@@ -64,14 +65,25 @@ export function BaseMapSelector() {
 }
 
 export function ModeSelector() {
-    const modeId = useLensStore((state) => state.modeId);
-    const datasetId = useLensStore((state) => state.datasetId);
-    const datasetYear = useLensStore((state) => state.datasetYear);
-    const compareDatasetYear = useLensStore((state) => state.compareDatasetYear);
-    const setMode = useLensStore((state) => state.setMode);
-    const setDatasetYear = useLensStore((state) => state.setDatasetYear);
-    const setCompareDatasetYear = useLensStore((state) => state.setCompareDatasetYear);
-    const swapYears = useLensStore((state) => state.swapYears);
+    const {
+        modeId,
+        datasetId,
+        datasetYear,
+        compareDatasetYear,
+        setMode,
+        setDatasetYear,
+        setCompareDatasetYear,
+        swapYears,
+    } = useLensStore(useShallow((state) => ({
+        modeId: state.modeId,
+        datasetId: state.datasetId,
+        datasetYear: state.datasetYear,
+        compareDatasetYear: state.compareDatasetYear,
+        setMode: state.setMode,
+        setDatasetYear: state.setDatasetYear,
+        setCompareDatasetYear: state.setCompareDatasetYear,
+        swapYears: state.swapYears,
+    })));
     const dataset = getDataset(datasetId);
     const years = Array.from(
         { length: dataset.endingYear - dataset.startingYear + 1 },
@@ -143,11 +155,19 @@ export function ModeSelector() {
 }
 
 export function DatasetSelector() {
-    const open = useLensStore((state) => state.advancedControlsOpen);
-    const datasetId = useLensStore((state) => state.datasetId);
-    const datasetDataTypeId = useLensStore((state) => state.datasetDataTypeId);
-    const setDataset = useLensStore((state) => state.setDataset);
-    const setDatasetDataType = useLensStore((state) => state.setDatasetDataType);
+    const {
+        open,
+        datasetId,
+        datasetDataTypeId,
+        setDataset,
+        setDatasetDataType,
+    } = useLensStore(useShallow((state) => ({
+        open: state.advancedControlsOpen,
+        datasetId: state.datasetId,
+        datasetDataTypeId: state.datasetDataTypeId,
+        setDataset: state.setDataset,
+        setDatasetDataType: state.setDatasetDataType,
+    })));
     const dataset = getDataset(datasetId);
 
     return (

--- a/lens/src/components/lens-legend.tsx
+++ b/lens/src/components/lens-legend.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { FeatureCharacteristic, type FeatureSetting } from '@/models/dataset';
 import { getDataset, getDatasetDataType, isComparisonMode } from '@/models/lens-store';
 import { CollapsiblePanel } from '@/components/lens-controls';
@@ -19,14 +20,25 @@ export function LensLegend({
     primaryBounds,
     comparisonBounds,
 }: LensLegendProps) {
-    const modeId = useLensStore((state) => state.modeId);
-    const datasetId = useLensStore((state) => state.datasetId);
-    const datasetDataTypeId = useLensStore((state) => state.datasetDataTypeId);
-    const datasetYear = useLensStore((state) => state.datasetYear);
-    const compareDatasetYear = useLensStore((state) => state.compareDatasetYear);
-    const features = useLensStore((state) => state.features);
-    const toggleFeature = useLensStore((state) => state.toggleFeature);
-    const toggleAdvancedControls = useLensStore((state) => state.toggleAdvancedControls);
+    const {
+        modeId,
+        datasetId,
+        datasetDataTypeId,
+        datasetYear,
+        compareDatasetYear,
+        features,
+        toggleFeature,
+        toggleAdvancedControls,
+    } = useLensStore(useShallow((state) => ({
+        modeId: state.modeId,
+        datasetId: state.datasetId,
+        datasetDataTypeId: state.datasetDataTypeId,
+        datasetYear: state.datasetYear,
+        compareDatasetYear: state.compareDatasetYear,
+        features: state.features,
+        toggleFeature: state.toggleFeature,
+        toggleAdvancedControls: state.toggleAdvancedControls,
+    })));
     const comparisonMode = isComparisonMode(modeId);
     const dataset = getDataset(datasetId);
     const dataType = getDatasetDataType(dataset, datasetDataTypeId);
@@ -44,6 +56,7 @@ export function LensLegend({
         }
 
         const controller = new AbortController();
+        const fetchComparison = comparisonMode && Boolean(comparisonBounds);
         const timeout = window.setTimeout(async () => {
             setLoading(true);
             try {
@@ -56,7 +69,7 @@ export function LensLegend({
                         controller.signal,
                     ),
                 ];
-                if (comparisonMode && comparisonBounds) {
+                if (fetchComparison && comparisonBounds) {
                     requests.push(fetchAreaTotals(
                         areaServerPath,
                         `${dataset.datasetIdPrefix}${compareDatasetYear}`,
@@ -66,9 +79,14 @@ export function LensLegend({
                     ));
                 }
 
-                const [nextAreas, nextComparisonAreas = {}] = await Promise.all(requests);
+                const [nextAreas, nextComparisonAreas] = await Promise.all(requests);
+                // Keep prior totals until replacement arrives (stale-while-revalidate).
                 setAreas(nextAreas);
-                setComparisonAreas(nextComparisonAreas);
+                if (fetchComparison) {
+                    setComparisonAreas(nextComparisonAreas ?? {});
+                } else if (!comparisonMode) {
+                    setComparisonAreas({});
+                }
             } catch (error) {
                 if (!(error instanceof DOMException && error.name === 'AbortError')) {
                     console.error('updateLegend error:', error);

--- a/lens/src/components/lens-map.tsx
+++ b/lens/src/components/lens-map.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import ReactMap, {
     AttributionControl,
     Layer,
@@ -18,6 +19,7 @@ import type {
 import { ExtendedDatasetDataTypes } from '@/models/dataset';
 import { BaseMaps, BaseMapType } from '@/models/lens-config';
 import { getDataset, getDatasetDataType } from '@/models/lens-store';
+import { lensOverlaySourceId } from '@/models/lens-overlay-source';
 import { useLensStore } from '@/components/lens-store-context';
 import type { MapBounds } from '@/components/lens-legend';
 
@@ -65,27 +67,48 @@ export function LensMap({
     year,
 }: LensMapProps) {
     const mapRef = useRef<MapRef>(null);
-    const modeId = useLensStore((state) => state.modeId);
-    const datasetId = useLensStore((state) => state.datasetId);
-    const datasetDataTypeId = useLensStore((state) => state.datasetDataTypeId);
-    const basemapId = useLensStore((state) => state.basemapId);
-    const features = useLensStore((state) => state.features);
-    const viewState = useLensStore((state) => state.viewState);
-    const setViewState = useLensStore((state) => state.setViewState);
+    const {
+        modeId,
+        datasetId,
+        datasetDataTypeId,
+        basemapId,
+        features,
+        viewState,
+        setViewState,
+    } = useLensStore(useShallow((state) => ({
+        modeId: state.modeId,
+        datasetId: state.datasetId,
+        datasetDataTypeId: state.datasetDataTypeId,
+        basemapId: state.basemapId,
+        features: state.features,
+        viewState: state.viewState,
+        setViewState: state.setViewState,
+    })));
     const dataset = getDataset(datasetId);
     const dataType = getDatasetDataType(dataset, datasetDataTypeId);
-    const sourceId = `${dataset.id}_${year}_${mapRole}`;
+    const sourceId = lensOverlaySourceId(dataset.id, mapRole);
     const layerId = `${sourceId}_fill`;
+    const pendingSourceId = `${sourceId}_pending`;
     const [popup, setPopup] = useState<PopupState | null>(null);
     const [mapIdle, setMapIdle] = useState(false);
     const mapStyle = mapStyleOverride
         ?? BaseMaps.find((basemap) => basemap.id === basemapId)?.style
         ?? BaseMapType.Fallback;
-    const source: LensMapSource = mapSource ?? {
+    const desiredSource: LensMapSource = mapSource ?? {
         type: 'vector',
         sourceLayer: dataset.datasetLayerId,
         url: `${tileServerPath}/data/${dataset.datasetIdPrefix}${year}.json`,
     };
+    const desiredSourceKey = lensMapSourceKey(desiredSource);
+    const [visibleSource, setVisibleSource] = useState(desiredSource);
+    const [pendingSource, setPendingSource] = useState<LensMapSource | null>(null);
+    const visibleSourceKey = lensMapSourceKey(visibleSource);
+    const desiredSourceRef = useRef(desiredSource);
+    const visibleSourceRef = useRef(visibleSource);
+    const pendingSourceRef = useRef(pendingSource);
+    desiredSourceRef.current = desiredSource;
+    visibleSourceRef.current = visibleSource;
+    pendingSourceRef.current = pendingSource;
     const fillColor = useMemo(() => [
         'match',
         ['get', dataType.value],
@@ -149,14 +172,65 @@ export function LensMap({
     }, [modeId]);
 
     useEffect(() => {
+        if (desiredSourceKey === visibleSourceKey) {
+            setPendingSource(null);
+            return;
+        }
+
+        const desired = desiredSourceRef.current;
+        const visible = visibleSourceRef.current;
+
+        // Dataset / source-layer identity changed — swap immediately.
+        if (!sameSourceIdentity(desired, visible)) {
+            setVisibleSource(desired);
+            setPendingSource(null);
+            setMapIdle(false);
+            setPopup(null);
+            return;
+        }
+
+        // Year / tile URL change — keep the painted layer until the replacement is loaded.
+        setPendingSource(desired);
+        setPopup(null);
+    }, [desiredSourceKey, visibleSourceKey]);
+
+    useEffect(() => {
         setMapIdle(false);
         setPopup(null);
-    }, [mapStyle, sourceId]);
+    }, [mapStyle]);
+
+    const promotePendingIfReady = useCallback(() => {
+        const pending = pendingSourceRef.current;
+        if (!pending) {
+            return;
+        }
+
+        const map = mapRef.current?.getMap();
+        if (!map?.getSource(pendingSourceId) || !map.isSourceLoaded(pendingSourceId)) {
+            return;
+        }
+
+        setVisibleSource(pending);
+        setPendingSource(null);
+    }, [pendingSourceId]);
 
     const handleIdle = useCallback(() => {
+        promotePendingIfReady();
         setMapIdle(true);
         onIdle?.();
-    }, [onIdle]);
+    }, [onIdle, promotePendingIfReady]);
+
+    useEffect(() => {
+        if (!pendingSource) {
+            return;
+        }
+
+        // GeoJSON (and already-cached vector) can be ready before the next idle.
+        const frame = window.requestAnimationFrame(() => {
+            promotePendingIfReady();
+        });
+        return () => window.cancelAnimationFrame(frame);
+    }, [pendingSource, promotePendingIfReady]);
 
     return (
         <div
@@ -190,26 +264,26 @@ export function LensMap({
                 style={{ height: '100%', width: '100%' }}
             >
                 <AttributionControl compact={window.innerWidth <= 1340} />
-                {source.type === 'vector' ? (
-                    <Source key={sourceId} id={sourceId} type="vector" url={source.url}>
-                        <Layer
-                            id={layerId}
-                            type="fill"
-                            source-layer={source.sourceLayer}
-                            filter={filter}
-                            paint={fillPaint}
-                        />
-                    </Source>
-                ) : (
-                    <Source key={sourceId} id={sourceId} type="geojson" data={source.data}>
-                        <Layer
-                            id={layerId}
-                            type="fill"
-                            filter={filter}
-                            paint={fillPaint}
-                        />
-                    </Source>
-                )}
+                <LensMapSourceLayers
+                    fillPaint={fillPaint}
+                    filter={filter}
+                    layerId={layerId}
+                    source={visibleSource}
+                    sourceId={sourceId}
+                />
+                {pendingSource ? (
+                    <LensMapSourceLayers
+                        fillPaint={{
+                            ...fillPaint,
+                            'fill-opacity': 0,
+                            'fill-opacity-transition': { duration: 0 },
+                        }}
+                        filter={filter}
+                        layerId={`${layerId}_pending`}
+                        source={pendingSource}
+                        sourceId={pendingSourceId}
+                    />
+                ) : null}
                 {popup && mapIdle ? (
                     <ReactMapPopup
                         className="wee-map-popup"
@@ -227,6 +301,66 @@ export function LensMap({
             </ReactMap>
         </div>
     );
+}
+
+function LensMapSourceLayers({
+    fillPaint,
+    filter,
+    layerId,
+    source,
+    sourceId,
+}: {
+    fillPaint: {
+        'fill-color': ExpressionSpecification;
+        'fill-opacity': number;
+        'fill-opacity-transition': { duration: number };
+    };
+    filter: FilterSpecification | undefined;
+    layerId: string;
+    source: LensMapSource;
+    sourceId: string;
+}) {
+    if (source.type === 'vector') {
+        return (
+            <Source id={sourceId} type="vector" url={source.url}>
+                <Layer
+                    id={layerId}
+                    type="fill"
+                    source-layer={source.sourceLayer}
+                    filter={filter}
+                    paint={fillPaint}
+                />
+            </Source>
+        );
+    }
+
+    return (
+        <Source id={sourceId} type="geojson" data={source.data}>
+            <Layer
+                id={layerId}
+                type="fill"
+                filter={filter}
+                paint={fillPaint}
+            />
+        </Source>
+    );
+}
+
+function lensMapSourceKey(source: LensMapSource): string {
+    if (source.type === 'vector') {
+        return `vector:${source.sourceLayer}:${source.url}`;
+    }
+    return `geojson:${JSON.stringify(source.data)}`;
+}
+
+function sameSourceIdentity(left: LensMapSource, right: LensMapSource): boolean {
+    if (left.type !== right.type) {
+        return false;
+    }
+    if (left.type === 'vector' && right.type === 'vector') {
+        return left.sourceLayer === right.sourceLayer;
+    }
+    return true;
 }
 
 const datasetTypePropertyKeys = new Set<string>(Object.values(ExtendedDatasetDataTypes));

--- a/lens/src/components/lens-store-context.tsx
+++ b/lens/src/components/lens-store-context.tsx
@@ -2,6 +2,11 @@ import { createContext, useContext, type ReactNode } from 'react';
 import { useStore } from 'zustand';
 import type { LensStore, LensStoreApi } from '@/models/lens-store';
 
+/**
+ * Zustand holds Lens domain state. This Context only injects the store instance
+ * so tests/harness can mount an isolated store — it is not a second state tree.
+ * Ephemeral UI (map bounds, swipe position) stays in component useState.
+ */
 const LensStoreContext = createContext<LensStoreApi | null>(null);
 
 type LensStoreProviderProps = {

--- a/lens/src/hooks/use-lens-url-sync.ts
+++ b/lens/src/hooks/use-lens-url-sync.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { serializeLensUrl } from '@/models/lens-url';
+import { useLensStore } from '@/components/lens-store-context';
+
+export function useLensUrlSync() {
+    const {
+        modeId,
+        datasetId,
+        datasetDataTypeId,
+        basemapId,
+        datasetYear,
+        compareDatasetYear,
+        viewState,
+    } = useLensStore(useShallow((state) => ({
+        modeId: state.modeId,
+        datasetId: state.datasetId,
+        datasetDataTypeId: state.datasetDataTypeId,
+        basemapId: state.basemapId,
+        datasetYear: state.datasetYear,
+        compareDatasetYear: state.compareDatasetYear,
+        viewState: state.viewState,
+    })));
+
+    useEffect(() => {
+        const timeout = window.setTimeout(() => {
+            const { query, url } = serializeLensUrl(new URL(window.location.href), {
+                coordinates: {
+                    lat: viewState.latitude,
+                    lng: viewState.longitude,
+                    zoom: viewState.zoom,
+                    pitch: viewState.pitch,
+                },
+                modeId,
+                datasetId,
+                datasetDataTypeId,
+                basemapId,
+                datasetYear,
+                compareDatasetYear,
+            });
+
+            try {
+                window.history.replaceState(null, '', query);
+            } catch (error) {
+                console.error('Failed to update the URL:', error);
+            }
+
+            const shareInput = document.getElementById('share-url');
+            if (shareInput instanceof HTMLInputElement) {
+                shareInput.value = url.toString();
+            }
+        }, 250);
+
+        return () => window.clearTimeout(timeout);
+    }, [
+        basemapId,
+        compareDatasetYear,
+        datasetDataTypeId,
+        datasetId,
+        datasetYear,
+        modeId,
+        viewState,
+    ]);
+}

--- a/lens/src/models/lens-overlay-source.test.ts
+++ b/lens/src/models/lens-overlay-source.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { lensOverlaySourceId } from '@/models/lens-overlay-source';
+
+describe('lensOverlaySourceId', () => {
+    it('is stable across years (year is not part of the id)', () => {
+        expect(lensOverlaySourceId('lcm', 'primary')).toBe('lcm_primary');
+        expect(lensOverlaySourceId('lcm', 'comparison')).toBe('lcm_comparison');
+        expect(lensOverlaySourceId('lcm', 'primary')).not.toContain('2012');
+        expect(lensOverlaySourceId('lcm', 'primary')).not.toContain('2022');
+    });
+});

--- a/lens/src/models/lens-overlay-source.ts
+++ b/lens/src/models/lens-overlay-source.ts
@@ -1,0 +1,7 @@
+/** Stable across year changes so React does not tear down the painted overlay. */
+export function lensOverlaySourceId(
+    datasetId: string,
+    mapRole: 'primary' | 'comparison',
+): string {
+    return `${datasetId}_${mapRole}`;
+}

--- a/lens/test-harness/harness-app.tsx
+++ b/lens/test-harness/harness-app.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { MapModeTypes } from '@/models/lens-config';
 import { isComparisonMode } from '@/models/lens-store';
 import { BaseMapSelector, ModeSelector } from '@/components/lens-controls';
@@ -13,9 +14,12 @@ type HarnessAppProps = {
 };
 
 export function HarnessApp({ mapboxToken, onMapIdle }: HarnessAppProps) {
-    const modeId = useLensStore((state) => state.modeId);
-    const datasetYear = useLensStore((state) => state.datasetYear);
-    const compareDatasetYear = useLensStore((state) => state.compareDatasetYear);
+    const { modeId, datasetYear, compareDatasetYear } = useLensStore(useShallow((state) => ({
+        modeId: state.modeId,
+        datasetYear: state.datasetYear,
+        compareDatasetYear: state.compareDatasetYear,
+    })));
+
     const [swipePosition, setSwipePosition] = useState(50);
     const comparisonMode = isComparisonMode(modeId);
     const ignoreBounds = useCallback((_bounds: MapBounds) => undefined, []);

--- a/lens/vitest.map-harness.config.ts
+++ b/lens/vitest.map-harness.config.ts
@@ -12,7 +12,11 @@ export default defineConfig({
     define: {
         'import.meta.env.MAPBOX_TOKEN': JSON.stringify(process.env.MAPBOX_TOKEN ?? env.MAPBOX_TOKEN ?? ''),
     },
+    optimizeDeps: {
+        include: ['zustand/react/shallow'],
+    },
     resolve: {
+        dedupe: ['react', 'react-dom'],
         alias: {
             '@': fileURLToPath(new URL('./src', import.meta.url)),
         },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,10 @@ const headless = !headed;
 export default defineConfig({
     resolve: {
         alias,
+        dedupe: ['react', 'react-dom'],
+    },
+    optimizeDeps: {
+        include: ['zustand/react/shallow'],
     },
     test: {
         coverage: {
@@ -27,6 +31,7 @@ export default defineConfig({
             {
                 resolve: {
                     alias,
+                    dedupe: ['react', 'react-dom'],
                 },
                 test: {
                     name: 'node',
@@ -38,6 +43,10 @@ export default defineConfig({
             {
                 resolve: {
                     alias,
+                    dedupe: ['react', 'react-dom'],
+                },
+                optimizeDeps: {
+                    include: ['zustand/react/shallow'],
                 },
                 test: {
                     name: 'browser',


### PR DESCRIPTION
## Summary
- **[NEV-64](https://linear.app/neveroffdev/issue/NEV-64/extract-uselensurlsync-into-its-own-hook):** Extract share-URL sync into `useLensUrlSync` so `LensApp` only composes map, controls, and legend.
- **[NEV-65](https://linear.app/neveroffdev/issue/NEV-65/zustand-subscription-hygiene-useshallow-keep-context-no-slices):** Use Zustand `useShallow` for multi-field store picks; keep Context for harness isolation and document the Zustand / Context / local-state split in `AGENTS.md`.
- **[NEV-66](https://linear.app/neveroffdev/issue/NEV-66/keep-map-and-legend-stable-across-year-changes):** Dual-buffer map overlays with stable source IDs so year changes keep the prior paint until the replacement tiles load; legend keeps prior area totals until the next response arrives.
- Stabilize Vitest browser deps (React dedupe + `zustand/react/shallow` pre-bundle) so `useShallow` works in browser and map-harness configs.

## Test plan
- [ ] Change Timeline year: map overlay should not blank to basemap-only before the new year tiles paint
- [ ] Legend totals should not flash to “None”/0 while the next area request is in flight
- [ ] Split/Swipe: change comparison year and confirm the same stability
- [ ] Share URL / browser history still updates for mode, dataset, years, and view
- [ ] `pnpm test` (node + browser) and map-harness suite still pass with the Vitest dep tweaks